### PR TITLE
ci: Remove gcc-multilib package

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ apt-get install -y --no-install-recommends software-properties-common \
 apt-get install -y --no-install-recommends gcc g++ gperf bison flex texinfo \
 	help2man make libncurses5-dev python3-dev autoconf automake libtool \
 	libtool-bin gawk wget bzip2 xz-utils unzip patch libstdc++6 diffstat \
-	gcc-multilib build-essential chrpath socat cpio python python3 \
+	build-essential chrpath socat cpio python python3 \
 	python3.8-dev python3-pip python3-pexpect debianutils iputils-ping
 
 # Install packages for creating SDK packages


### PR DESCRIPTION
We don't need the gcc-multilib package so remove it and save a bit of
space.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>