### PR TITLE
Dockerfile: Add ninja-build and meson

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get install -y --no-install-recommends \
 	python3-dev autoconf automake libtool libtool-bin gawk wget bzip2 \
 	xz-utils unzip patch libstdc++6 diffstat build-essential chrpath \
 	socat cpio python python3 python3-pip python3-pexpect \
-	python3-setuptools debianutils iputils-ping ca-certificates
+	python3-setuptools debianutils iputils-ping ca-certificates \
+	ninja-build
 
 # Install python3.8-dev for build w/GDB
 RUN apt-get install -y --no-install-recommends python3.8-dev
@@ -45,6 +46,9 @@ RUN apt-get install -y --no-install-recommends makeself p7zip-full tree curl
 
 # Install python packages to allow upload to aws S3
 RUN pip3 install awscli
+
+# Install meson to allow building picolibc
+RUN pip3 install meson
 
 # Grab a new git
 RUN add-apt-repository ppa:git-core/ppa -y && \


### PR DESCRIPTION
This commit installs the ninja-build and meson utilities, which are
required for building the picolibc.

Note that meson is installed through the pip because the distro-
provided meson package (0.52) is outdated and does not meet the
minimum version requirement for building the picolibc (0.53).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>