### PR TITLE
Dockerfile: Use Debian 10 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,11 +47,6 @@ RUN pip3 install awscli
 # Install meson to allow building picolibc
 RUN pip3 install meson
 
-# Grab a new git
-RUN add-apt-repository ppa:git-core/ppa -y && \
-    apt-get update && \
-    apt-get install -y git
-
 # Add build-agent user
 RUN groupadd -g $GID -o build-agent && \
     useradd -u $UID -m -g build-agent build-agent --shell /bin/bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM python:3.10-buster
 
 ARG UID=1001
 ARG GID=1001
@@ -37,9 +37,6 @@ RUN apt-get install -y --no-install-recommends \
 	socat cpio python python3 python3-pip python3-pexpect \
 	python3-setuptools debianutils iputils-ping ca-certificates \
 	ninja-build
-
-# Install python3.8-dev for build w/GDB
-RUN apt-get install -y --no-install-recommends python3.8-dev
 
 # Install packages for creating SDK packages
 RUN apt-get install -y --no-install-recommends makeself p7zip-full tree curl


### PR DESCRIPTION
This commit updates the Dockerfile to use Debian 10 (Buster) as the base image in order to increase the minimum compatible glibc version to 2.28, as per [1].

[1] https://github.com/zephyrproject-rtos/sdk-ng/issues/764

Related to https://github.com/zephyrproject-rtos/sdk-ng/issues/764