### PR TITLE
Dockerfile: Add step to upgrade all packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV SHELL=/bin/bash
 # Install packages
 RUN apt-get clean
 RUN apt-get update
+RUN apt-get upgrade -y
 
 # software-properties for add-apt-repository
 # locales for LANG support


### PR DESCRIPTION
The `python:3.10-buster` base image already has various packages pre-installed.

This commit adds a step to upgrade all pre-installed packages prior to installing any additional packages in order to ensure that the packages included in the Docker image are up-to-date.