### PR TITLE
Dockerfile: Use Python 3.8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-buster
+FROM python:3.8-buster
 
 ARG UID=1001
 ARG GID=1001


### PR DESCRIPTION
This commit updates the Dockerfile to use the Debian 10 image with Python 3.8 pre-installed, until the Python 3.10 migration is complete.