### PR TITLE
Dockerfile: Use Python 3.10 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-buster
+FROM python:3.10-buster
 
 ARG UID=1001
 ARG GID=1001


### PR DESCRIPTION
This commit updates the Dockerfile to use the Debian 10 image with Python 3.10 pre-installed in preparation for linking against Python 3.10 for gdb-py.

Note that Yocto Python 3.10 compatibility issues have been resolved.