### PR TITLE
Dockerfile: Add CMake 3.30.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.10-buster
 
+ARG CMAKE_VERSION=3.30.5
+
 ARG UID=1001
 ARG GID=1001
 
@@ -41,6 +43,11 @@ RUN apt-get install -y --no-install-recommends \
 
 # Install packages for creating SDK packages
 RUN apt-get install -y --no-install-recommends makeself p7zip-full tree curl
+
+# Install CMake
+RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${HOSTTYPE}.sh && \
+	chmod +x cmake-${CMAKE_VERSION}-linux-${HOSTTYPE}.sh && \
+	./cmake-${CMAKE_VERSION}-linux-${HOSTTYPE}.sh --skip-license --prefix=/usr/local
 
 # Install python packages to allow upload to aws S3
 RUN pip3 install awscli

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG CMAKE_VERSION=3.30.5
 ARG UID=1001
 ARG GID=1001
 
-# Make bash the default shell
-ENV SHELL=/bin/bash
+# Set default shell during Docker image build to bash
+SHELL ["/bin/bash", "-c"]
 
 # Install packages
 RUN apt-get clean


### PR DESCRIPTION
This commit adds CMake 3.30.5 to the SDK build image.

Note that the distro CMake package is not used because it is too outdated and not compatible with the LLVM build process.