### PR TITLE
mingw-build: Build winpthreads library

### DIFF
--- a/mingw-build.sh
+++ b/mingw-build.sh
@@ -87,6 +87,16 @@ build_mingw_toolchain() {
   make install -j$(nproc)
   popd
 
+  # Build MinGW winpthreads
+  mkdir mingw-winpthreads
+  pushd mingw-winpthreads
+  ../../src/mingw-w64-v${MINGW_VERSION}/mingw-w64-libraries/winpthreads/configure \
+    --prefix=${prefix}/x86_64-w64-mingw32 \
+    --host=x86_64-w64-mingw32
+  make -j$(nproc)
+  make install
+  popd
+
   # Build final GCC
   pushd gcc
   make -j$(nproc)

--- a/mingw-build.sh
+++ b/mingw-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 BINUTILS_VERSION=2.42
 GCC_VERSION=13.2.0
 MINGW_VERSION=12.0.0


### PR DESCRIPTION
Build MinGW-w64 winpthreads library, which enables pthread support on
MinGW-w64 toolchain.

pthread support is required when compiling libgcc with posix thread
model.

Fixes https://github.com/zephyrproject-rtos/docker-sdk-build/issues/28