### PR TITLE
Dockerfile: Use archive.debian.org APT source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,12 @@ ARG GID=1001
 # Set default shell during Docker image build to bash
 SHELL ["/bin/bash", "-c"]
 
-# Install packages
-RUN apt-get clean
-RUN apt-get update
-RUN apt-get upgrade -y
+# Upgrade packages
+RUN <<EOF
+	apt-get clean
+	apt-get update
+	apt-get upgrade -y
+EOF
 
 # software-properties for add-apt-repository
 # locales for LANG support

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ SHELL ["/bin/bash", "-c"]
 
 # Upgrade packages
 RUN <<EOF
+	sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+
 	apt-get clean
 	apt-get update
 	apt-get upgrade -y


### PR DESCRIPTION
Use `archive.debian.org` as the main APT source because `deb.debian.org`
no longer hosts the APT packages for Debian Buster (10).